### PR TITLE
Change #angularjs to ##angular

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ![logo](ng-irc.png) Angular in IRC
 
-> Compilation of Angular-related resources from the IRC #angularjs channel.
+> Compilation of Angular-related resources from the IRC ##angular channel on freenode.
 
 ## A few suggestions getting help
 

--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
 
     <script>
         window.$docsify = {
-            name: '#angularjs',
+            name: '##angular',
             repo: 'ngirc/ng-irc',
             loadSidebar: true
         }


### PR DESCRIPTION
Hi @albertosantini,
trampi from #angularjs here :-)
Freenode has renamed #angularjs to ##angular, as we are a community-driven channel instead of an official support channel. I changed the references accordingly.

All the best,
trampi